### PR TITLE
move logging to journctl

### DIFF
--- a/docker-compose/prod/api-worker/docker-compose.yml
+++ b/docker-compose/prod/api-worker/docker-compose.yml
@@ -13,7 +13,6 @@ services:
     env_file:
       - ../../../config/podverse-api-prod.env
     logging:
-      driver: "json-file"
+      driver: "syslog"
       options:
-        max-file: "1"
-        max-size: "50m"
+        tag: "{{.ImageName}}/{{.Name}}/{{.ID}}"

--- a/docker-compose/prod/db/docker-compose.yml
+++ b/docker-compose/prod/db/docker-compose.yml
@@ -20,10 +20,9 @@ services:
     restart: always
     shm_size: 1gb
     logging:
-      driver: "json-file"
+      driver: "syslog"
       options:
-        max-file: "1"
-        max-size: "50m"
+        tag: "{{.ImageName}}/{{.Name}}/{{.ID}}"
 
   podverse_manticore:
     image: manticoresearch/manticore:4.2.0
@@ -46,7 +45,6 @@ services:
       - /opt/podverse-ops/manticore/data:/var/lib/manticore
       - /opt/podverse-ops/manticore/manticore.conf:/etc/manticoresearch/manticore.conf
     logging:
-      driver: 'json-file'
+      driver: "syslog"
       options:
-        max-file: '1'
-        max-size: '50m'
+        tag: "{{.ImageName}}/{{.Name}}/{{.ID}}"

--- a/docker-compose/prod/srv/docker-compose.yml
+++ b/docker-compose/prod/srv/docker-compose.yml
@@ -26,10 +26,9 @@ services:
     networks:
       - nginx-proxy
     logging:
-      driver: "json-file"
+      driver: "syslog"
       options:
-        max-file: "1"
-        max-size: "50m"
+        tag: "{{.ImageName}}/{{.Name}}/{{.ID}}"
 
   podverse_web:
     image: podverse/podverse_web
@@ -50,7 +49,6 @@ services:
       - nginx-proxy
     command: npm start
     logging:
-      driver: "json-file"
+      driver: "syslog"
       options:
-        max-file: "1"
-        max-size: "50m"
+        tag: "{{.ImageName}}/{{.Name}}/{{.ID}}"


### PR DESCRIPTION
This has been working directly on the api work node for a while. It should be brought in as our new standard.
This will also allow the logs to be viewable in other monitoring tools without the need to view in the terminal.